### PR TITLE
Add binary classification summary statistics to contingency table

### DIFF
--- a/compare_results.py
+++ b/compare_results.py
@@ -52,18 +52,52 @@ def build_contingency(pred: Dict[str, str], truth: Dict[str, str]) -> Dict[str, 
 
 
 def save_contingency(table: Dict[str, Dict[str, int]], path: str) -> None:
-    """Save contingency table to a CSV file."""
+    """Save contingency table to a CSV file and output basic statistics.
+
+    In addition to the full contingency table, if the classification task is
+    binary, this function also appends a small summary of ``hit`` (true
+    positive), ``miss`` (false negative), ``false alarm`` (false positive) and
+    ``correct negative`` (true negative) counts to the CSV and prints them to
+    stdout.  For multi-class problems the summary is skipped.
+    """
+
     if not table:
         print("No overlapping images found.")
         return
+
     actual_classes = sorted(table.keys())
     pred_classes = sorted({p for counts in table.values() for p in counts})
+
     with open(path, 'w', newline='', encoding='utf-8') as f:
         writer = csv.writer(f)
         writer.writerow(['Actual\\Pred'] + pred_classes)
         for actual in actual_classes:
             row = [actual] + [table[actual].get(pred, 0) for pred in pred_classes]
             writer.writerow(row)
+
+        # Append binary classification statistics if applicable
+        all_classes = sorted(set(actual_classes) | set(pred_classes))
+        if len(all_classes) == 2:
+            pos, neg = all_classes
+            hits = table.get(pos, {}).get(pos, 0)
+            misses = table.get(pos, {}).get(neg, 0)
+            false_alarms = table.get(neg, {}).get(pos, 0)
+            correct_negatives = table.get(neg, {}).get(neg, 0)
+
+            writer.writerow([])
+            writer.writerow(['Statistic', 'Count'])
+            writer.writerow(['Hit', hits])
+            writer.writerow(['Miss', misses])
+            writer.writerow(['False Alarm', false_alarms])
+            writer.writerow(['Correct Negative', correct_negatives])
+
+            print(
+                f"Hit: {hits}, Miss: {misses}, False Alarm: {false_alarms}, "
+                f"Correct Negative: {correct_negatives}"
+            )
+        else:
+            print("More than two classes detected; skipping hit/miss statistics.")
+
     print(f"Contingency table saved to {path}")
 
 


### PR DESCRIPTION
## Summary
- extend compare_results.py to append hit, miss, false alarm, and correct negative counts when evaluating binary classification results
- print these statistics to stdout and include them at the end of the CSV output

## Testing
- `python compare_results.py --pred pred.csv --truth truth.csv --out table.csv`

------
https://chatgpt.com/codex/tasks/task_e_68b2de56db8c8327aa392ea6a75aa147